### PR TITLE
improve the gracefull stop of the robot

### DIFF
--- a/tests/test_god_mode.py
+++ b/tests/test_god_mode.py
@@ -38,7 +38,7 @@ class RobotContext:
         return self.cl
 
     def __exit__(self, type, value, tb):
-        self.robot.stop()
+        self.robot.stop(timeout=1)
         if os.path.exists(config.data_repo.path):
             shutil.rmtree(config.data_repo.path)
         j.clients.zrobot.delete('test')

--- a/tests/test_robot.py
+++ b/tests/test_robot.py
@@ -37,7 +37,7 @@ class TestRobot(unittest.TestCase):
             robot.set_data_repo(data_dir)
             robot.start(listen="localhost:6600", block=False)
             self.assertEqual(robot.address, ('127.0.0.1', 6600))
-            robot.stop()
+            robot.stop(timeout=1)
         self.assertIsNone(robot.address)
 
     def test_template_url(self):

--- a/tests/test_service_proxy.py
+++ b/tests/test_service_proxy.py
@@ -35,7 +35,7 @@ class TestServiceProxy(unittest.TestCase):
         self.robot.start(listen='127.0.0.1:6600', block=False, testing=True)
 
     def tearDown(self):
-        self.robot.stop()
+        self.robot.stop(timeout=1)
         if os.path.exists(config.data_repo.path):
             shutil.rmtree(config.data_repo.path)
         j.clients.zrobot.delete('test')

--- a/tests/test_zrobot_client.py
+++ b/tests/test_zrobot_client.py
@@ -33,7 +33,7 @@ class TestZRobotClient(unittest.TestCase):
         self.robot.start(listen='127.0.0.1:6600', block=False, testing=True)
 
     def tearDown(self):
-        self.robot.stop()
+        self.robot.stop(timeout=1)
         if os.path.exists(config.data_repo.path):
             shutil.rmtree(config.data_repo.path)
         # make sure we don't have any service loaded

--- a/zerorobot/robot/robot.py
+++ b/zerorobot/robot/robot.py
@@ -8,6 +8,7 @@ import gevent
 from gevent import GreenletExit
 from gevent.pool import Pool
 from gevent.pywsgi import WSGIServer
+from gevent.event import Event
 
 from js9 import j
 from zerorobot import service_collection as scol
@@ -34,18 +35,20 @@ class Robot:
     """
 
     def __init__(self):
-        self._started = False
-        self._block = True
+        self._stop_event = Event()
+        self._stop_event.set()
         self.data_repo_url = None
         self._http = None  # server handler
-        self.addr = None
+        self._addr = None
         self._sig_handler = []
 
     @property
+    def started(self):
+        return not self._stop_event.is_set()
+
+    @property
     def address(self):
-        if self._http:
-            return self._http.address
-        return None
+        return self._addr
 
     def set_data_repo(self, url):
         """
@@ -93,6 +96,8 @@ class Robot:
         start the rest web server
         load the services from the local git repository
         """
+        self._stop_event.clear()
+
         config.mode = mode
         config.god = god  # when true, this allow to get data and logs from services using the REST API
 
@@ -116,8 +121,6 @@ class Robot:
 
          # configure authentication middleware
         _configure_authentication(admin_organization, user_organization)
-
-        self._block = block
 
         self._sig_handler.append(gevent.signal(signal.SIGINT, self.stop))
 
@@ -146,36 +149,49 @@ class Robot:
         hostport = _split_hostport(listen)
         self._http = WSGIServer(hostport, app, spawn=pool, log=logger, error_log=logger)
         self._http.start()
+        self._addr = self._http.address
         logger.info("robot running at %s:%s" % hostport)
 
         if block:
-            self._http.serve_forever()
-            # this is executed when self.stop is called.
-            # here no more requests are comming in, we can safely save all services
-            self._save_services()
-        else:
-            self._http.start()
+            try:
+                # wait until stop() is called
+                self._stop_event.wait()
+            finally:
+                gevent.Greenlet.spawn(self.stop, timeout=60).join()
 
-    def stop(self):
+    def stop(self, timeout=30):
         """
-        stop receiving requests
-        gracefully stop all the services
-        serialize all services state to disk
+        1. stop receiving requests on the REST API
+        2. wait all currently active request finishes
+        3. stop all services
+        4. wait all services stop gracefully
+        5. serialize all services state to disk
+        6. exit the process
         """
+        logger.info('stopping robot')
+
         # prevent the signal handler to be called again if
         # more signal are received
         for h in self._sig_handler:
             h.cancel()
 
-        logger.info('stopping robot')
-        self._http.stop()
-        self._http = None
+        logger.info("stop REST API")
+        logger.info("waiting request to finish")
+        self._http.stop(timeout=10)
+        self._addr = None
 
-        # if we don't block, we can gracefully shutdown here
-        # cause we're not in a sig handler
-        if self._block is False:
-            # here no more requests are comming in, we can safely save all services
-            self._save_services()
+        logger.info("waiting for services to stop")
+        for service in scol.list_services():
+            try:
+                service._gracefull_stop(timeout=None)
+            except Exception as err:
+                logger.warning('exception raised while waiting %s %s (%s) to finish: %s', service.template_uid.name, service.name, service.guid, err)
+
+        # here no more requests are comming in, we can safely save all services
+        self._save_services()
+
+        # notify we can exist the process
+        self._stop_event.set()
 
     def _save_services(self):
         """

--- a/zerorobot/task/task_list.py
+++ b/zerorobot/task/task_list.py
@@ -55,12 +55,12 @@ class TaskList:
         if self._done:
             self._done.close()
 
-    def get(self):
+    def get(self, timeout=None):
         """
         pop out a task from the task list
         this call is blocking when the task list is empty
         """
-        _, task = self._queue.get()
+        _, task = self._queue.get(timeout=timeout)
         self.current = task
         nr_task_waiting.labels(service_guid=self.service.guid).dec()
         return task

--- a/zerorobot/template/base.py
+++ b/zerorobot/template/base.py
@@ -14,6 +14,8 @@ from logging.handlers import RotatingFileHandler
 from uuid import uuid4
 
 import gevent
+from gevent.event import Event
+from gevent.queue import Empty
 
 from js9 import j
 from zerorobot import service_collection as scol
@@ -101,7 +103,16 @@ class GreenletsMgr:
         for gl in self.gls.values():
             gl.kill(block=False)
         if wait:
-            gevent.wait(list(self.gls.values()), timeout=timeout)
+            self.wait_all(timeout)
+
+    def stop_recurring(self, wait=False, timeout=None):
+        for key, gl in self.gls.items():
+            if key.startswith('recurring_'):
+                logger.info("kill %s" % key)
+                gl.kill(block=wait, timeout=timeout)
+
+    def wait_all(self, timeout=None):
+        gevent.wait(list(self.gls.values()), timeout=timeout)
 
 
 class TemplateBase:
@@ -120,6 +131,7 @@ class TemplateBase:
 
     def __init__(self, name=None, guid=None, data=None):
         self.template_dir = os.path.dirname(sys.modules.get(str(self.template_uid)).__file__)
+        self.__stop_event = Event()
         self.guid = guid or str(uuid4())
         self.name = name or self.guid
         self._public = False
@@ -195,9 +207,14 @@ class TemplateBase:
         if config.SERVICE_LOADED:
             config.SERVICE_LOADED.wait()
 
-        while True:
+        while not self.__stop_event.is_set():
             try:
-                task = self.task_list.get()
+                try:
+                    # wait for 5 second before re-trying the exit condition
+                    task = self.task_list.get(timeout=5)
+                except Empty:
+                    continue
+
                 task.service = self
                 try:
                     task.execute()
@@ -205,8 +222,9 @@ class TemplateBase:
                     task_latency.labels(action_name=task.action_name, template_uid=str(self.template_uid)).observe(task.duration)
                     # notify the task list that this task is done
                     self.task_list.done(task)
-                    if task.state == TASK_STATE_ERROR:
+                    if task.state == TASK_STATE_ERROR and task.eco:
                         self.logger.error("error executing action %s:\n%s" % (task.action_name, task.eco.traceback))
+
             except gevent.GreenletExit:
                 # TODO: gracefull shutdown
                 # make sure the task storage is close properly
@@ -276,6 +294,28 @@ class TemplateBase:
 
         gl = gevent.Greenlet(_recurring_action, self, action, period)
         self.gl_mgr.add("recurring_" + action, gl)
+
+    def _gracefull_stop(self, timeout=None):
+        """
+        Gracefully stop the service
+
+        1. kill all the recurring greenlets
+        2. if there is a task in progress wait till timout, then kill
+        """
+        self.logger.info("stopping service %s (%s)", self.name, self.guid)
+        self.__stop_event.set()  # make the main loop exit
+
+        # stop all recurring action and processing of task list
+        self.gl_mgr.stop_recurring(wait=False)
+        main_gl = self.gl_mgr.get('executor')
+
+        # if the main loop is busy with a task, wait timeout
+        # then kill
+        try:
+            if self.task_list.current:
+                main_gl.join(timeout=timeout)
+        finally:
+            main_gl.kill(block=True, timeout=1)
 
     def delete(self, wait=False, timeout=60, die=False):
         """


### PR DESCRIPTION
when stopping it now does:
1. stop receiving requests on the REST API
2. wait all currently active request finishes
3. stop all services
4. wait all services stop gracefully
5. serialize all services state to disk
6. exit the process