### PR TITLE
Allow 0-robot to start with zdb backend for configmanager 

### DIFF
--- a/cmd/zrobot
+++ b/cmd/zrobot
@@ -23,14 +23,12 @@ entry_point.add_command(blueprint)
 entry_point.add_command(godtoken)
 
 if __name__ == "__main__":
-    from zerorobot.config.data_repo import _parse_zdb
-
     from jumpscale import j
-    CONFIG_PATH = '/opt/var/data/zrobot/zrobot_data/data_repo.yaml'
+    if  j.core.state.configGetFromDict("myconfig", "backend") == "db":
+        namespace =  j.core.state.configGetFromDict("myconfig", "namespace", "")
+        if namespace:
+           j.tools.configmanager.set_namespace(namespace)
+        else:
+            raise RuntimeError("Working in zdb backend mode and don't have a namespace")
 
-    if j.sal.fs.exists(CONFIG_PATH):
-        zdburl = j.data.serializer.yaml.load(CONFIG_PATH)['zdb_url']
-        _, _, _, namespace = _parse_zdb(zdburl)
-        j.tools.configmanager.set_namespace(namespace)
-        
     entry_point()

--- a/cmd/zrobot
+++ b/cmd/zrobot
@@ -23,4 +23,30 @@ entry_point.add_command(blueprint)
 entry_point.add_command(godtoken)
 
 if __name__ == "__main__":
+    from urllib.parse import urlparse
+    def _parse_zdb(line):
+        """
+        parse a zdb url
+
+        zdb://admin_password@hostname:port/namespace
+
+        return (admin_password, hostname, port, namespace)
+        """
+
+        u = urlparse(line)
+        if u.scheme != 'zdb':
+            raise ValueError('scheme should be bcdb, not %s', u.scheme)
+
+        path = u.path[1:] if u.path and u.path[0] == '/' else u.path
+
+        return (u.username, u.hostname, u.port, path)
+
+    from jumpscale import j
+    CONFIG_PATH = '/opt/var/data/zrobot/zrobot_data/data_repo.yaml'
+
+    if j.sal.fs.exists(CONFIG_PATH):
+        zdburl = j.data.serializer.yaml.load(CONFIG_PATH)['zdb_url']
+        _, _, _, namespace = _parse_zdb(zdburl)
+        j.tools.configmanager.set_namespace(namespace)
+        
     entry_point()

--- a/cmd/zrobot
+++ b/cmd/zrobot
@@ -23,23 +23,7 @@ entry_point.add_command(blueprint)
 entry_point.add_command(godtoken)
 
 if __name__ == "__main__":
-    from urllib.parse import urlparse
-    def _parse_zdb(line):
-        """
-        parse a zdb url
-
-        zdb://admin_password@hostname:port/namespace
-
-        return (admin_password, hostname, port, namespace)
-        """
-
-        u = urlparse(line)
-        if u.scheme != 'zdb':
-            raise ValueError('scheme should be bcdb, not %s', u.scheme)
-
-        path = u.path[1:] if u.path and u.path[0] == '/' else u.path
-
-        return (u.username, u.hostname, u.port, path)
+    from zerorobot.config.data_repo import _parse_zdb
 
     from jumpscale import j
     CONFIG_PATH = '/opt/var/data/zrobot/zrobot_data/data_repo.yaml'

--- a/cmd/zrobot
+++ b/cmd/zrobot
@@ -23,12 +23,4 @@ entry_point.add_command(blueprint)
 entry_point.add_command(godtoken)
 
 if __name__ == "__main__":
-    from jumpscale import j
-    if  j.core.state.configGetFromDict("myconfig", "backend") == "db":
-        namespace =  j.core.state.configGetFromDict("myconfig", "namespace", "")
-        if namespace:
-           j.tools.configmanager.set_namespace(namespace)
-        else:
-            raise RuntimeError("Working in zdb backend mode and don't have a namespace")
-
     entry_point()

--- a/zerorobot/cli/server.py
+++ b/zerorobot/cli/server.py
@@ -69,6 +69,18 @@ def start(listen, data_repo, template_repo, config_repo, config_key, debug,
         robot.add_template_repo(url)
 
     robot.set_data_repo(data_repo)
+    if not config_repo:
+        namespace_in_cfg = j.core.state.configGetFromDict("myconfig", "namespace", "")
+        if namespace_in_cfg:
+            config_repo_path = j.sal.fs.joinPaths(j.dirs.HOMEDIR, "configmgrsandboxes", namespace_in_cfg) 
+            if j.sal.fs.exists(config_repo_path):
+                config_repo = config_repo_path
+
+    if not config_key:
+        config_key_path = j.sal.fs.joinPaths(j.dirs.HOMEDIR, "configmgrsandboxes", namespace_in_cfg, "keys", "key")
+        if j.sal.fs.exists(config_key_path):
+            config_key = config_key_path
+    
     robot.set_config_repo(config_repo, config_key)
 
     robot.start(listen=listen,

--- a/zerorobot/cli/server.py
+++ b/zerorobot/cli/server.py
@@ -15,6 +15,13 @@ from zerorobot.robot import Robot
 telegram_logger = logging.getLogger('telegram_logger')
 telegram_logger.disabled = True
 
+if  j.core.state.configGetFromDict("myconfig", "backend") == "db":
+    namespace =  j.core.state.configGetFromDict("myconfig", "namespace", "")
+    if namespace:
+        j.tools.configmanager.set_namespace(namespace)
+    else:
+        raise RuntimeError("Working in zdb backend mode and don't have a namespace")
+
 
 @click.group()
 def server():
@@ -69,14 +76,15 @@ def start(listen, data_repo, template_repo, config_repo, config_key, debug,
         robot.add_template_repo(url)
 
     robot.set_data_repo(data_repo)
-    if not config_repo:
+    backend =  j.core.state.configGetFromDict("myconfig", "backend", "")
+    if not config_repo and backend == "db" :
         namespace_in_cfg = j.core.state.configGetFromDict("myconfig", "namespace", "")
         if namespace_in_cfg:
             config_repo_path = j.sal.fs.joinPaths(j.dirs.HOMEDIR, "configmgrsandboxes", namespace_in_cfg) 
             if j.sal.fs.exists(config_repo_path):
                 config_repo = config_repo_path
 
-    if not config_key:
+    if not config_key and backend == "db" :
         config_key_path = j.sal.fs.joinPaths(j.dirs.HOMEDIR, "configmgrsandboxes", namespace_in_cfg, "keys", "key")
         if j.sal.fs.exists(config_key_path):
             config_key = config_key_path

--- a/zerorobot/cli/server.py
+++ b/zerorobot/cli/server.py
@@ -15,13 +15,6 @@ from zerorobot.robot import Robot
 telegram_logger = logging.getLogger('telegram_logger')
 telegram_logger.disabled = True
 
-if  j.core.state.configGetFromDict("myconfig", "backend") == "db":
-    namespace =  j.core.state.configGetFromDict("myconfig", "namespace", "")
-    if namespace:
-        j.tools.configmanager.set_namespace(namespace)
-    else:
-        raise RuntimeError("Working in zdb backend mode and don't have a namespace")
-
 
 @click.group()
 def server():
@@ -93,6 +86,16 @@ def start(listen, data_repo, template_repo, config_repo, config_key, debug,
 
     j.logger.handlers_level_set(level)
     j.logger.loggers_level_set(level)
+
+    # Check if configmanager is configured to zdb backend and has a namespace configured
+    if  j.core.state.configGetFromDict("myconfig", "backend") == "db":
+        namespace =  j.core.state.configGetFromDict("myconfig", "namespace", "")
+        if namespace:
+            j.tools.configmanager.set_namespace(namespace)
+        else:
+            raise RuntimeError("Working in zdb backend mode and don't have a namespace")
+
+
 
     if (telegram_bot_token and not telegram_chat_id) or (telegram_chat_id and not telegram_bot_token):
         raise ValueError("To enable telegram error logging, you need to specify both the --telegram-bot-token and the --telegram-chat-id options")

--- a/zerorobot/config/data_repo.py
+++ b/zerorobot/config/data_repo.py
@@ -88,4 +88,4 @@ def _parse_zdb(line):
 
     path = u.path[1:] if u.path and u.path[0] == '/' else u.path
 
-    return (u.password, u.hostname, u.port, path)
+    return (u.username, u.hostname, u.port, path)

--- a/zerorobot/robot/robot.py
+++ b/zerorobot/robot/robot.py
@@ -97,10 +97,8 @@ class Robot:
 
         config.mode = mode
         config.god = god  # when true, this allow to get data and logs from services using the REST API
-
         if config.data_repo is None:
             raise RuntimeError("Not data repository set. Robot doesn't know where to save data.")
-
         if not j.tools.configmanager.path:
             raise RuntimeError("config manager is not configured, can't continue")
 
@@ -111,6 +109,7 @@ class Robot:
         logger.info("data directory: %s" % config.data_repo.path)
         logger.info("config directory: %s" % j.tools.configmanager.path)
         logger.info("sshkey used: %s" % os.path.expanduser(os.path.join('~/.ssh', j.tools.configmanager.keyname)))
+        logger.info("configmanager sshkeypath: "+ j.tools.configmanager.keypath)
 
         # configure prometheus monitoring
         if not kwargs.get('testing', False):

--- a/zerorobot/robot/robot.py
+++ b/zerorobot/robot/robot.py
@@ -108,8 +108,10 @@ class Robot:
         logger = j.logger.get('zerorobot')
         logger.info("data directory: %s" % config.data_repo.path)
         logger.info("config directory: %s" % j.tools.configmanager.path)
-        logger.info("sshkey used: %s" % os.path.expanduser(os.path.join('~/.ssh', j.tools.configmanager.keyname)))
-        logger.info("configmanager sshkeypath: "+ j.tools.configmanager.keypath)
+        keypath = j.tools.configmanager.keypath
+        if not keypath:
+            keypath = os.path.expanduser(os.path.join('~/.ssh', j.tools.configmanager.keyname))
+        logger.info("sshkey used: %s" % keypath)
 
         # configure prometheus monitoring
         if not kwargs.get('testing', False):


### PR DESCRIPTION
Changes for starting config manager with a 0-db backend

if backend is db we set the namespace to be used to the configmanager process using set_namespace
otherwise:  we infer the robot sandbox located in HOMEDIR/configmgrsandboxes and start the robot with it and with the key in that sandbox